### PR TITLE
Create paths for handling data cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/EnvironmentalDashboard/citywide-dashboard-backend#readme",
   "dependencies": {
+    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "mongodb": "^3.3.5",
     "nodemon": "^2.0.2"

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -35,6 +35,9 @@ router.get('/:_id', (req, res) => (
 /**
  * I wonder if this is too specific to a particular implementation?
  * But, I think for now it makes sense to exist.
+ *
+ * Note: this function does assume any view will have gauges attached.
+ * For now, this is a fair assumption to make, but it might break in the future?
  */
 router.get('/:_id/gauges', (req, res) => (
   getGlyphById(req.params._id)
@@ -42,5 +45,18 @@ router.get('/:_id/gauges', (req, res) => (
     res.json(result.view ? result.view.gauges : [])
   ))
 ));
+
+/**
+ * This also assumes that any view will have gauges attached.
+ */
+router.get('/:_id/gauges/:index', (req, res) => {
+  const realIndex = req.params.index - 1;
+
+  getGlyphById(req.params._id)
+  .then(result => (
+    res.json((result.view && realIndex > 0 && result.view.gauges.length > realIndex)
+      ? result.view.gauges[realIndex] : {})
+  ));
+});
 
 module.exports = router;

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -19,7 +19,8 @@ const getGlyphById = id => (
 );
 
 router.get('/', (req, res) => (
-  db.collection.find({}).sort({ layer: 1 }).toArray().then(result => (
+  db.collection.find({}).sort({ layer: 1 }).toArray()
+  .then(result => (
     res.json(result)
   ))
 ));

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -128,7 +128,7 @@ router.post('/:_id/gauges/:index/cache', (req, res) => {
     db.collection.updateOne(
       {
         _id: req.params._id,
-        'view.gauges': { $exists: true }
+        [`view.gauges.${req.params.index - 1}`]: { $exists: true }
       },
       {
         $set: {

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -75,4 +75,22 @@ router.get('/:_id/gauges/:index', (req, res) => {
   ));
 });
 
+router.post('/:_id/cache', (req, res) => (
+    req.body.data
+    ?
+      db.collection.updateOne(
+        { _id: req.params._id },
+        {
+          $set: {
+            cachedData: req.body.data
+          }
+        }
+      )
+      .then(result => res.json(result))
+    :
+      res.json({
+        'errors': ['No data provided!']
+      })
+));
+
 module.exports = router;

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -5,23 +5,30 @@ const ObjectId = require('mongodb').ObjectId;
 
 const db = require('./db');
 
+const getGlyphById = id => (
+  db.collection.findOne({
+    _id: id
+  }).then(result => (
+    // This ternary situation should not have to happen in an ideal world.
+    result ? result : db.collection.findOne({
+      _id: new ObjectId(id)
+    }).then(oresult => (
+      oresult
+    ))
+  ))
+);
+
 router.get('/', (req, res) => (
   db.collection.find({}).sort({ layer: 1 }).toArray().then(result => (
     res.json(result)
   ))
 ));
 
-router.get('/:_id', (req, res) => {
-  db.collection.findOne({
-    _id: req.params._id
-  }).then(result => (
-    // This ternary situation should not have to happen in an ideal world.
-    result ? res.json(result) : db.collection.findOne({
-      _id: new ObjectId(req.params._id)
-    }).then(oresult => (
-      res.json(oresult)
-    ))
+router.get('/:_id', (req, res) => (
+  getGlyphById(req.params._id)
+  .then(result => (
+    res.json(result)
   ))
-});
+));
 
 module.exports = router;

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -18,6 +18,23 @@ const getGlyphById = id => (
   ))
 );
 
+const getGlyphGaugesById = id => (
+  getGlyphById(id)
+  .then(result => (
+    result.view ? result.view.gauges : []
+  ))
+);
+
+/**
+ * Gets a glyph gauge by both a glyph ID and a gauge index.
+ */
+const getGlyphGauge = (id, index) => (
+  getGlyphGaugesById(id)
+  .then(result => (
+    (index >= 0 && result.length > index) ? result[index] : {}
+  ))
+)
+
 router.get('/', (req, res) => (
   db.collection.find({}).sort({ layer: 1 }).toArray()
   .then(result => (
@@ -40,9 +57,9 @@ router.get('/:_id', (req, res) => (
  * For now, this is a fair assumption to make, but it might break in the future?
  */
 router.get('/:_id/gauges', (req, res) => (
-  getGlyphById(req.params._id)
+  getGlyphGaugesById(req.params._id)
   .then(result => (
-    res.json(result.view ? result.view.gauges : [])
+    res.json(result)
   ))
 ));
 
@@ -52,10 +69,9 @@ router.get('/:_id/gauges', (req, res) => (
 router.get('/:_id/gauges/:index', (req, res) => {
   const realIndex = req.params.index - 1;
 
-  getGlyphById(req.params._id)
+  getGlyphGauge(req.params._id, realIndex)
   .then(result => (
-    res.json((result.view && realIndex > 0 && result.view.gauges.length > realIndex)
-      ? result.view.gauges[realIndex] : {})
+    res.json(result)
   ));
 });
 

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -1,11 +1,26 @@
 const express = require('express');
 const router = express.Router();
 
+const ObjectId = require('mongodb').ObjectId;
+
 const db = require('./db');
 
-router.get('/', (req, res) => {
-  return db.collection.find({}).sort({ layer: 1 }).toArray().then(result => (
+router.get('/', (req, res) => (
+  db.collection.find({}).sort({ layer: 1 }).toArray().then(result => (
     res.json(result)
+  ))
+));
+
+router.get('/:_id', (req, res) => {
+  db.collection.findOne({
+    _id: req.params._id
+  }).then(result => (
+    // This ternary situation should not have to happen in an ideal world.
+    result ? res.json(result) : db.collection.findOne({
+      _id: new ObjectId(req.params._id)
+    }).then(oresult => (
+      res.json(oresult)
+    ))
   ))
 });
 

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -31,4 +31,15 @@ router.get('/:_id', (req, res) => (
   ))
 ));
 
+/**
+ * I wonder if this is too specific to a particular implementation?
+ * But, I think for now it makes sense to exist.
+ */
+router.get('/:_id/gauges', (req, res) => (
+  getGlyphById(req.params._id)
+  .then(result => (
+    res.json(result.view ? result.view.gauges : [])
+  ))
+));
+
 module.exports = router;

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -117,4 +117,27 @@ router.post('/:_id/cache', (req, res) => {
   }
 });
 
+router.post('/:_id/gauges/:index/cache', (req, res) => {
+  const processed = processCacheRequest(req);
+
+  if (processed.errors.length > 0) {
+    res.json({
+      'errors': processed.errors
+    });
+  } else {
+    db.collection.updateOne(
+      {
+        _id: req.params._id,
+        'view.gauges': { $exists: true }
+      },
+      {
+        $set: {
+          [`view.gauges.${req.params.index - 1}.data`]: processed.parsed
+        }
+      }
+    )
+    .then(result => res.json(result));
+  }
+});
+
 module.exports = router;

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -75,22 +75,43 @@ router.get('/:_id/gauges/:index', (req, res) => {
   ));
 });
 
-router.post('/:_id/cache', (req, res) => (
-    req.body.data
-    ?
-      db.collection.updateOne(
-        { _id: req.params._id },
-        {
-          $set: {
-            cachedData: req.body.data
-          }
-        }
-      )
-      .then(result => res.json(result))
-    :
+router.post('/:_id/cache', (req, res) => {
+  let errors = [];
+  let parsed = {};
+
+  if (!req.body.data) {
+    errors.push('No data provided!');
+
+    res.json({
+      'errors': errors
+    });
+
+    return;
+  }
+
+  try {
+    parsed = JSON.parse(req.body.data);
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      errors.push('Invalid JSON body!');
+
       res.json({
-        'errors': ['No data provided!']
-      })
-));
+        'errors': errors
+      });
+
+      return;
+    }
+  }
+
+  db.collection.updateOne(
+    { _id: req.params._id },
+    {
+      $set: {
+        data: JSON.parse(req.body.data)
+      }
+    }
+  )
+  .then(result => res.json(result));
+});
 
 module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -1,11 +1,15 @@
 const express = require('express');
 const server = express();
+const bodyParser = require('body-parser');
 const PORT = 80;
 
 const DEVELOPMENT = 0;
 const ENVIRONMENT = DEVELOPMENT;
 
 const glyphs = require('./glyphs');
+
+server.use(bodyParser.json());
+server.use(bodyParser.urlencoded({ extended: true }));
 
 const routers = {
   '/glyphs': glyphs


### PR DESCRIPTION
Unfortunately, Community Voices items got created such that I have not been able to think about this since January 6 (at least, according to my notes).  It looks like the code has not been touched for almost a month.  So, I include the following changelog, but it is pretty general due to how far out it is.
- Get individual glyphs
- Get gauges from individual glyphs
- Post data into the data cache