### PR TITLE
Data validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ Requests to the API should always be done with the header Content-Type set to
 `application/json`.
 In limited testing with `application/x-www-form-urlencoded`, ensuring data integrity
 became more difficult.
+
+## Testing Requests / Sample Requests
+
+Better documentation is a future goal.
+For now, contact @Sammidysam for a Postman set up for testing requests.
+These test requests provide an example of how requests should look.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ The database volume that is referenced in the code can be established and manage
 
 When running in production, would need to switch the Dockerfile to not start
 `nodemon`, among some other things.
+It is the hope that this will become automatically managed like other applications
+eventually.
+
+## Sending requests
+
+Requests to the API should always be done with the header Content-Type set to
+`application/json`.
+In limited testing with `application/x-www-form-urlencoded`, ensuring data integrity
+became more difficult.

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -59,7 +59,7 @@ const processCacheRequest = req => {
   return processed;
 };
 
-const processMessageRequest = (req, type) => {
+const processMessageRequest = (req) => {
   const processed = {
     errors: [],
     parsed: {}
@@ -72,10 +72,14 @@ const processMessageRequest = (req, type) => {
     processed.errors.push('Invalid index provided!');
   }
 
-  if ((type === 'view' && typeof req.body.probability !== 'number') || (type === 'gauge' && !Array.isArray(req.body.probability))) {
-    processed.errors.push('Invalid datatype!');
-  }
+  const isGauge = req.url.includes("gauges");
 
+  if (isGauge && !Array.isArray(req.body.probability)) {
+    processed.errors.push('Gauge message probability should be an array!');
+  } else if (!isGauge && typeof req.body.probability !== 'number') {
+    processed.errors.push('View message probability should be an integer!')
+  }
+  
   try {
     processed.parsed.text = req.body.text;
     processed.parsed.probability = req.body.probability;
@@ -199,7 +203,7 @@ router.post('/:_id/gauges/:index/cache', (req, res) => {
 
 //Used to update a message attached to a gauge
 router.post('/:_id/gauges/:index/messages/:num', (req, res) => {
-  const processed = processMessageRequest(req, 'gauge');
+  const processed = processMessageRequest(req);
 
   if (processed.errors.length > 0) {
     res.json({
@@ -212,7 +216,7 @@ router.post('/:_id/gauges/:index/messages/:num', (req, res) => {
 });
 
 router.post('/:_id/gauges/:index/messages', (req, res) => {
-  const processed = processMessageRequest(req, 'gauge');
+  const processed = processMessageRequest(req);
 
   if (processed.errors.length > 0) {
     res.json({
@@ -234,7 +238,7 @@ router.post('/:_id/gauges/:index/messages', (req, res) => {
 });
 
 router.post('/:_id/messages', (req, res) => {
-  const processed = processMessageRequest(req, 'view');
+  const processed = processMessageRequest(req);
 
   if (processed.errors.length > 0) {
     res.json({
@@ -258,7 +262,7 @@ router.post('/:_id/messages', (req, res) => {
 
 //Used to update a message attached to a view
 router.post('/:_id/messages/:num', (req, res) => {
-  const processed = processMessageRequest(req, 'view');
+  const processed = processMessageRequest(req);
 
   if (processed.errors.length > 0) {
     res.json({

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -95,7 +95,8 @@ const processMessageRequest = (req, type) => {
 const updateMessages = (id, path, req) => {
   return db.collection.updateOne(
     {
-      _id: new ObjectId(id)
+      _id: new ObjectId(id),
+      [path]: { $exists: true }
     },
     {
       $set: {

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -59,7 +59,7 @@ const processCacheRequest = req => {
   return processed;
 };
 
-const processMessageRequest = req => {
+const processMessageRequest = (req, type) => {
   const processed = {
     errors: [],
     parsed: {}
@@ -70,6 +70,10 @@ const processMessageRequest = req => {
   }
   if (req.params.index < 1 || req.params.num < 1) {
     processed.errors.push('Invalid index provided!');
+  }
+
+  if ((type === 'view' && typeof req.body.probability !== 'number') || (type === 'gauge' && !Array.isArray(req.body.probability))) {
+    processed.errors.push('Invalid datatype!');
   }
 
   try {
@@ -194,7 +198,7 @@ router.post('/:_id/gauges/:index/cache', (req, res) => {
 
 //Used to update a message attached to a gauge
 router.post('/:_id/gauges/:index/messages/:num', (req, res) => {
-  const processed = processMessageRequest(req);
+  const processed = processMessageRequest(req, 'gauge');
 
   if (processed.errors.length > 0) {
     res.json({
@@ -207,7 +211,7 @@ router.post('/:_id/gauges/:index/messages/:num', (req, res) => {
 });
 
 router.post('/:_id/gauges/:index/messages', (req, res) => {
-  const processed = processMessageRequest(req);
+  const processed = processMessageRequest(req, 'gauge');
 
   if (processed.errors.length > 0) {
     res.json({
@@ -229,7 +233,7 @@ router.post('/:_id/gauges/:index/messages', (req, res) => {
 });
 
 router.post('/:_id/messages', (req, res) => {
-  const processed = processMessageRequest(req);
+  const processed = processMessageRequest(req, 'view');
 
   if (processed.errors.length > 0) {
     res.json({
@@ -253,7 +257,7 @@ router.post('/:_id/messages', (req, res) => {
 
 //Used to update a message attached to a view
 router.post('/:_id/messages/:num', (req, res) => {
-  const processed = processMessageRequest(req);
+  const processed = processMessageRequest(req, 'view');
 
   if (processed.errors.length > 0) {
     res.json({


### PR DESCRIPTION
This just adds some validation/checking things to the backend, specifically for the routes used by the Message Editor to address some issues that were brought up by @Sammidysam  when testing. The backend should now make sure that "probability" is a correct datatype depending on whether a gauge or view is being updated, and now additionally should now validate that a path actually exists before attempting to update it. This way, if the index sent by the frontend is incorrect for some reason, the backend should just reject the request and not create a bunch of null values to fill in the space.