### PR TITLE
Metadata

### DIFF
--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -146,10 +146,6 @@ const importMessages = (line, metaTypes) => {
   const message = line.split(",");
   const viewMessage = (message[1] === viewPath);
 
-  const newMessage = {"text": message[2], "probability": (viewMessage) ? Number(message[3]):message.splice(3, 5).map(num => Number(num))};
-  if (metaTypes && metaTypes.length) newMessage = {...newMessage, "metadata" : []};           //Make a field in the message object for metadata only if metadata exists
-  const path = (viewMessage) ? "view" : `view.gauges.${message[1]}`;
-
   const metaText = (viewMessage) ? message.splice(0,3):message.splice(0,5);
 
   const metaArray = {};
@@ -157,7 +153,11 @@ const importMessages = (line, metaTypes) => {
     metaArray[metaTypes[i]] = metaText[i];
   }
 
-  newMessage.metadata = metaArray;
+  const newMessage = {"text": message[2], "probability": (viewMessage) ? Number(message[3]):message.splice(3, 5).map(num => Number(num))};
+
+  if (metaTypes) newMessage = {...newMessage, "metadata" : metaArray}; //Make a field in the message object for metadata only if metadata exists
+
+  const path = (viewMessage) ? "view" : `view.gauges.${message[1]}`;
 
   return db.collection.updateOne(
     {

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -144,26 +144,24 @@ const updateMessages = (id, path, req) => {
 */
 const viewPath = "intro"
 
-const importMessages = (line) => {
+const importMessages = (line, metaTypes) => {
   const message = line.split(FIELD_SEPERATOR);
 
-  if (message.length !== 4 && message.length !== 8)
+  if (message.length !== 4 && message.length !== 8)ta
     return ERROR_STRING;
 
   const metaText = (viewMessage) ? message.splice(0,3):message.splice(0,5);
 
-  const metaArray = {};
-  for (let i=0; i<metadata.length; i++) {
+  let metaArray = {};
+  for (let i=0; i<metaTypes.length; i++) {
     metaArray[metaTypes[i]] = metaText[i];
   }
 
   const newMessage = {"text": message[2], "probability": (viewMessage) ? Number(message[3]):message.splice(3, 5).map(num => Number(num))};
 
-  if (metaTypes) newMessage = {...newMessage, "metadata" : metaArray};
+  if (metaTypes.length > 0) newMessage = {...newMessage, "metadata" : metaArray};
 
   const viewMessage = (message[1] === viewPath);
-
-  const newMessage = {"text": message[2], "probability": (viewMessage) ? Number(message[3]) : message.splice(3, 5).map(num => Number(num))};
 
   const path = (viewMessage) ? "view" : "view.gauges.$";
 
@@ -389,7 +387,7 @@ router.use(formidable()).post('/import', (req, res) => {
   } else {
     if (req.fields.type === "overwrite") clearMessages(req.files[""].path);
     let first = true;
-    const metadataFields = [];
+    let metadataFields = [];
     lineReader.eachLine(req.files[""].path, function(line) {
       if (first) {
         metadataFields = line.split(",").splice(0,4);  //View name, Guage index, Probability(1 or 5), Metadata...

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -149,8 +149,8 @@ const importMessages = (line, metaTypes) => {
 
   const viewMessage = (message[1] === viewPath);
 
-  if (message.length < 9)
-    return 'ERORR_STRING';
+  if (message.length < 8)
+    return ERROR_STRING;
 
   let metaText = [];
   for (let i=8; i<message.length; ++i) {
@@ -193,7 +193,7 @@ const clearMessages = (file, headers) => {
 
       const viewMessage = (message[1] === viewPath);
 
-      if (message.length < 9)
+      if (message.length < 8)
         return ERROR_STRING;
 
       const path = (viewMessage) ? "view" : "view.gauges.$";

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -152,9 +152,9 @@ const importMessages = (line, metaTypes) => {
 
   const metaText = (viewMessage) ? message.splice(0,3):message.splice(0,5);
 
-  const metaArray = {}
+  const metaArray = {};
   for (let i=0; i<metadata.length; i++) {
-    metaArray.push({`${metaTypes[i]}` : `${metaText[i]}`});
+    metaArray[metaTypes[i]] = metaText[i];
   }
 
   newMessage.metadata = metaArray;
@@ -364,7 +364,6 @@ router.post('/:_id/messages/:num', (req, res) => {
 router.use(formidable()).post('/import', (req, res) => {
   const processed = processImportRequest(req);
   const headers = (req.fields.headers) ? req.fields.headers:true;
-  res.send("Hello!!!!");
   let response = [];
   if (processed.errors.length > 0) {
     res.json({


### PR DESCRIPTION
This PR will allow for messages to be imported with metadata attached, following the format. VIEW_NAME,GAUGE_INDEX,MESSAGE,BINS(1 or 5),METADATA_FIELDS...
It's close, but for some reason MongoDB doesn't seem to see the `metadata` attribute of `newMessage` when I add this attribute in `importMessages`. But my general logic is: scan through the first line of the file and store the metadata fields in an array which gets passed into `importMessages` --> read through each line in `importMessages` and store the text entries for metadata in another array --> create a `metadata` attribute for the `newMessage` only if the `metadata` array exists --> loop over the metadata fields and text entries and push them onto the `newMessage` JSON object that then gets added with `db.collection.update`.

