### PR TITLE
Allow a path prefix to control where the routes begin

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
 #! /bin/bash
 
+# To use a path prefix: -e PATH_PREFIX=api/legacy/citywide-dashboard
 docker run -dit -p 3006:80 -v $(pwd)/src:/usr/src/app/src -v $(pwd)/migrate:/usr/src/app/migrate -v $(pwd)/package.json:/usr/src/app/package.json -v $(pwd)/package-lock.json:/usr/src/app/package-lock.json --restart always --link cwd-mongo:mongo --name cwd-be citywide-dashboard-backend

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,9 @@
 const express = require('express');
 const server = express();
 const bodyParser = require('body-parser');
+
 const PORT = 80;
+const PATH = process.env.PATH_PREFIX ? `/${process.env.PATH_PREFIX}` : '';
 
 const DEVELOPMENT = 0;
 const ENVIRONMENT = DEVELOPMENT;
@@ -27,7 +29,7 @@ if (ENVIRONMENT === DEVELOPMENT) {
 }
 
 Object.keys(routers).forEach(k => {
-  server.use(k, routers[k]);
+  server.use(`${PATH}${k}`, routers[k]);
 });
 
 server.listen(PORT, () => console.log(`Listening on port ${PORT}`));

--- a/src/server.js
+++ b/src/server.js
@@ -32,4 +32,6 @@ Object.keys(routers).forEach(k => {
   server.use(`${PATH}${k}`, routers[k]);
 });
 
+server.get('/check', (req, res) => res.sendStatus(200));
+
 server.listen(PORT, () => console.log(`Listening on port ${PORT}`));


### PR DESCRIPTION
To test this, would just add the commented line in `run.sh`, confirm that for you the application is now run in that path prefix, then change it back and make sure that development still works.  I am very confident it will still work because it worked for me and this is Docker.

This is just needed for production, since we have tons of applications running all over the place.