### PR TITLE
Change from gauge index to gauge title

### DIFF
--- a/migrate/scripts/gauge-name.js
+++ b/migrate/scripts/gauge-name.js
@@ -60,4 +60,4 @@ const run = collection => {
   });
 }
 
-module.exports { canRun, run };
+module.exports = { canRun, run };

--- a/migrate/scripts/gauge-name.js
+++ b/migrate/scripts/gauge-name.js
@@ -1,12 +1,7 @@
 const qs = require('querystring');
 
 const urltoGaugeName = url => {
-  if (!url) return url;
-  else {
-    const parsed = JSON.parse(JSON.stringify(qs.decode(url)));
-
-    return parsed.title.toLowerCase();
-  }
+  return qs.decode(url).title.toLowerCase();
 }
 
 

--- a/migrate/scripts/gauge-name.js
+++ b/migrate/scripts/gauge-name.js
@@ -5,7 +5,7 @@ const urltoGaugeName = url => {
 }
 
 
-const canRun = collection => {
+const canRun = collection => (
   new Promise((resolve, reject) => {
     collection.find({
       'view' : { $exists: true }
@@ -19,7 +19,7 @@ const canRun = collection => {
       resolve(gauges.map(e => e.some(g => g.url && !g.name)).some(e => e));
     });
   })
-};
+);
 
 const run = collection => {
   collection.find({

--- a/migrate/scripts/gauge-name.js
+++ b/migrate/scripts/gauge-name.js
@@ -1,7 +1,7 @@
 const qs = require('querystring');
 
 const urltoGaugeName = url => {
-  return qs.decode(url).title.toLowerCase();
+  return qs.decode(url).title();
 }
 
 
@@ -60,4 +60,4 @@ const run = collection => {
   });
 }
 
-module.exports = { canRun, run };
+module.exports { canRun, run };

--- a/migrate/scripts/url-to-data-url.js
+++ b/migrate/scripts/url-to-data-url.js
@@ -10,7 +10,7 @@ const urlToDataUrl = url => {
   }
 };
 
-const canRun = collection => {
+const canRun = collection => (
   new Promise((resolve, reject) => {
     collection.find({
       'view': {
@@ -27,7 +27,7 @@ const canRun = collection => {
       resolve(gauges.map(e => e.some(g => g.url && !g.data_url)).some(e => e));
     });
   })
-};
+);
 
 const run = collection => {
   collection.find({

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -156,7 +156,7 @@ const importMessages = (line) => {
 
   const path = (viewMessage) ? "view" : "view.gauges.$";
 
-  const query = (path === "view") ? {"view.name" : messages[0].toLowerCase()} : {"view.gauges.name": message[1].toLowerCase()};
+  const query = (path === "view") ? {"view.name" : messages[0].toLowerCase()} : {"view.gauges.name": { $regex : new RegExp(messages[1], "i") } } 
 
   if (path.match(/\u0000/g))
     return ERROR_STRING;

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -154,7 +154,7 @@ const importMessages = (line) => {
   //Not a big fan of how this works but unsure how to handle if it's an "Intro" message
   if (path == "view") {
       return db.collection.updateOne({
-          "view.gauges.name": message[0].toLowerCase()
+          "view.name": message[0].toLowerCase()
       },
       {
         $addToSet: {

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -154,21 +154,22 @@ const importMessages = (line) => {
   //Not a big fan of how this works but unsure how to handle if it's an "Intro" message
   if (path == "view") {
       return db.collection.updateOne({
-          "view.name": message[0].toLowerCase()
+          "view.gauges.name": message[0].toLowerCase()
       },
       {
         $addToSet: {
           [`${path}.messages`]: newMessage
         }
-      })
-  } else return db.collection.updateOne({
-      "view.gauges.name": message[1].toLowerCase();
-      },
-      {
-      $addToSet: {
-        "view.$.message": newMessage
-      }
-  })
+      });
+  }
+  return db.collection.updateOne({
+      "view.gauges.name": message[0].toLowerCase()
+  },
+  {
+    $addToSet: {
+      "view.gauges.$.message" : newMessage
+    }
+  });
 }
 
 const clearMessages = (file, headers) => {

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -156,7 +156,7 @@ const importMessages = (line) => {
 
   const path = (viewMessage) ? "view" : "view.gauges.$";
 
-  const query = (path === "view") ? {"view.name" : messages[0].toLowerCase()} : {"view.gauges.name": { $regex : new RegExp(messages[1], "i") } } 
+  const query = (path === "view") ? {"view.name" : message[0].toLowerCase()} : {"view.gauges.name": { $regex : new RegExp(message[1], "i") } } 
 
   if (path.match(/\u0000/g))
     return ERROR_STRING;

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -156,7 +156,7 @@ const importMessages = (line) => {
 
   const path = (viewMessage) ? "view" : "view.gauges.$";
 
-  const query = (path === "view") ? {"view.name" : messages[0].toLowerCase()} : {"view.gauges.name": message[1].toLowerCase()};
+  const query = (path === "view") ? {"view.name" : messages[0].toLowerCase()} : {"view.gauges.name": message[1]};
 
   if (path.match(/\u0000/g))
     return ERROR_STRING;

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -158,14 +158,14 @@ const importMessages = (line) => {
 
   const query = (path === "view") ? {"view.name" : messages[0].toLowerCase()} : {"view.gauges.name": message[1].toLowerCase()};
 
-  const insert = (path === "view") ? {[`${path}.messages`]: newMessage} : {"view.gauges.$.messages" : newMessage};
+  const insertion = (path === "view") ? {[`${path}.messages`]: newMessage} : {"view.gauges.$.messages" : newMessage};
 
   if (path.match(/\u0000/g))
     return errorString;
 
   return db.collection.updateOne(query,
     {
-      $addToSet: insert
+      $addToSet: insertion
     }
   )
 }

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -11,8 +11,8 @@ const db = require('./db');
 const sha256 = require('js-sha256');
 const salt = "719GxFYNgo";
 const pass = "700e78f75bf9abb38e9b2f61b227afe94c204947eb0227174c48f55a4dcc8139";
-const fieldSeperator = "\t";
-const errorString = 'error';
+const FIELD_SEPERATOR = "\t";
+const ERROR_STRING = 'error';
 
 const getGlyphById = id => (
   db.collection.findOne({
@@ -145,27 +145,27 @@ const updateMessages = (id, path, req) => {
 const viewPath = "intro"
 
 const importMessages = (line) => {
-  const message = line.split(fieldSeperator);
+  const message = line.split(FIELD_SEPERATOR);
 
   if (message.length !== 4 && message.length !== 8)
-    return errorString;
+    return ERROR_STRING;
 
   const viewMessage = (message[1] === viewPath);
 
   const newMessage = {"text": message[2], "probability": (viewMessage) ? Number(message[3]) : message.splice(3, 5).map(num => Number(num))};
 
-  const path = (viewMessage) ? "view" : `view.gauges.${message[1]}`;
+  const path = (viewMessage) ? "view" : "view.gauges.$";
 
   const query = (path === "view") ? {"view.name" : messages[0].toLowerCase()} : {"view.gauges.name": message[1].toLowerCase()};
 
-  const insertion = (path === "view") ? {[`${path}.messages`]: newMessage} : {"view.gauges.$.messages" : newMessage};
-
   if (path.match(/\u0000/g))
-    return errorString;
+    return ERROR_STRING;
 
   return db.collection.updateOne(query,
     {
-      $addToSet: insertion
+      $addToSet: {
+        [`${path}.messages`] : newMessage
+      }
     }
   )
 }

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -156,7 +156,7 @@ const importMessages = (line) => {
 
   const path = (viewMessage) ? "view" : "view.gauges.$";
 
-  const query = (path === "view") ? {"view.name" : messages[0].toLowerCase()} : {"view.gauges.name": message[1]};
+  const query = (path === "view") ? {"view.name" : messages[0].toLowerCase()} : {"view.gauges.name": message[1].toLowerCase()};
 
   if (path.match(/\u0000/g))
     return ERROR_STRING;

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -11,6 +11,8 @@ const db = require('./db');
 const sha256 = require('js-sha256');
 const salt = "719GxFYNgo";
 const pass = "700e78f75bf9abb38e9b2f61b227afe94c204947eb0227174c48f55a4dcc8139";
+const fieldSeperator = "\t";
+const errorString = 'error';
 
 const getGlyphById = id => (
   db.collection.findOne({
@@ -143,10 +145,10 @@ const updateMessages = (id, path, req) => {
 const viewPath = "intro"
 
 const importMessages = (line) => {
-  const message = line.split("\t");
+  const message = line.split(fieldSeperator);
 
   if (message.length !== 4 && message.length !== 8)
-    return 'error';
+    return errorString;
 
   const viewMessage = (message[1] === viewPath);
 
@@ -156,10 +158,10 @@ const importMessages = (line) => {
 
   const query = (path === "view") ? {"view.name" : messages[0].toLowerCase()} : {"view.gauges.name": message[1].toLowerCase()};
 
-  const insert = (path === "view") ? {[`${path}.messages`]: newMessage} : {"view.gauges.$.message" : newMessage};
+  const insert = (path === "view") ? {[`${path}.messages`]: newMessage} : {"view.gauges.$.messages" : newMessage};
 
   if (path.match(/\u0000/g))
-    return 'error';
+    return errorString;
 
   return db.collection.updateOne(query,
     {


### PR DESCRIPTION
This PR modifies the import structure so that we are able to refer to gauges by their name instead of index in future message spreadsheets. The commit has two parts: a migration script to add a `name` field to each `glyphs.view.gauges` in the database (which currently has `url`, `data_url`, and `data`, and modifying `glyphs.js` to route to the correct entry in mongoDB based on the gauge name instead of its index. 