### PR TITLE
checking for view messages and view gauges existence

### DIFF
--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -23,14 +23,14 @@ const getGlyphById = id => (
 const getGlyphGaugesById = id => (
   getGlyphById(id)
   .then(result => (
-    result.view ? result.view.gauges : []
+    result.view.gauges ? result.view.gauges : []
   ))
 );
 
 const getGlyphMessagesById = id => (
   getGlyphById(id)
   .then(result => (
-    result.view ? result.view.messages : []
+    result.view.messages ? result.view.messages : []
   ))
 );
 

--- a/src/glyphs.js
+++ b/src/glyphs.js
@@ -23,7 +23,7 @@ const getGlyphById = id => (
 const getGlyphGaugesById = id => (
   getGlyphById(id)
   .then(result => (
-    result.view.gauges ? result.view.gauges : []
+    (result.view && result.view.gauges) ? result.view.gauges : []
   ))
 );
 


### PR DESCRIPTION
Fixes bug that happened because `ObjectId` that had no view messages returned an empty string, not `[]`. I actually believe that the original code had the right idea and was aware that it needed to return `[]` but just forgot the little check to make sure each field existed in these two ternary expressions.