### PR TITLE
Add script to add the `data_url` field to relevant glyphs

### DIFF
--- a/migrate/scripts/electron-data.js
+++ b/migrate/scripts/electron-data.js
@@ -23,7 +23,11 @@ const run = collection => {
         { _id: idEntry._id },
         {
           $set: {
-            data_url: "https://qa.communityhub.cloud/data-hub/meters/compare/1414c3a0-cda7-11e8-9c46-02420aff0702/1414c3a0-cda7-11e8-9c46-02420aff0702"
+            data_url: "https://qa.communityhub.cloud/data-hub/meters/compare/1414c3a0-cda7-11e8-9c46-02420aff0702/1414c3a0-cda7-11e8-9c46-02420aff0702",
+            'animators.pathMover.maxDuration': idEntry.animators.pathMover.duration
+          },
+          $unset: {
+            'animators.pathMover.duration': ''
           }
         }
       )

--- a/migrate/scripts/electron-data.js
+++ b/migrate/scripts/electron-data.js
@@ -1,0 +1,40 @@
+const ObjectId = require('mongodb').ObjectID
+
+const canRun = collection => (
+  new Promise ((resolve, reject) => {
+    collection.find({
+      name: 'powerline'
+    })
+    .toArray()
+    .then(r => {
+      resolve(r.length > 0)
+    });
+  })
+)
+
+const run = collection => {
+  collection.find({
+    name: 'powerline'
+  })
+  .toArray()
+  .then(idEntries => {
+    idEntries.forEach(idEntry => {
+      collection.updateOne(
+        { _id: idEntry._id },
+        {
+          $set: {
+            data_url: "https://qa.communityhub.cloud/data-hub/meters/compare/1414c3a0-cda7-11e8-9c46-02420aff0702/1414c3a0-cda7-11e8-9c46-02420aff0702"
+          }
+        }
+      )
+      .then(wc => {
+        if (!wc.writeConcernError) {
+          console.log(`Successfully updated ${idEntry._id}`);
+        } else {
+          console.error(`Error updating ${idEntry._id}`);
+        }
+      })
+    })
+  })
+}
+module.exports = { canRun, run };


### PR DESCRIPTION
This is for https://github.com/EnvironmentalDashboard/citywide-dashboard.alpha/pull/37
I thought it would make sense to turn it into a quick script just since I don't like modifying production DB by hand